### PR TITLE
fix: security hardening, crash fixes, and dependency cleanup

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -16,7 +16,6 @@
     "drizzle-orm": "^0.39",
     "hono": "^4",
     "nanoid": "^5",
-    "oslo": "^1",
     "zod": "^3.24"
   },
   "devDependencies": {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -13,6 +13,11 @@ const app = new Hono();
 const uploadDir = resolve(import.meta.dir, "../data/uploads");
 
 app.use(logger());
+app.use(async (c, next) => {
+  await next();
+  c.header("X-Content-Type-Options", "nosniff");
+  c.header("X-Frame-Options", "DENY");
+});
 const allowedOrigins = process.env.ALLOWED_ORIGINS
   ? process.env.ALLOWED_ORIGINS.split(",").map((o) => o.trim())
   : [];

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -24,7 +24,7 @@ function createSession(c: Context, userId: string) {
   setCookie(c, "session", token, {
     httpOnly: true,
     secure: true,
-    sameSite: "none",
+    sameSite: "lax",
     path: "/",
     maxAge: SESSION_DURATION / 1000,
   });

--- a/apps/server/src/routes/databases.ts
+++ b/apps/server/src/routes/databases.ts
@@ -136,7 +136,10 @@ export const databaseRoutes = new Hono<AuthEnv>()
         .run();
     });
 
-    const page = db.select().from(pages).where(eq(pages.id, pageId)).get()!;
+    const page = db.select().from(pages).where(eq(pages.id, pageId)).get();
+    if (!page) {
+      return c.json({ error: "Failed to create database" }, 500);
+    }
     return c.json({ page }, 201);
   })
 
@@ -250,7 +253,11 @@ export const databaseRoutes = new Hono<AuthEnv>()
         .select()
         .from(databaseProperties)
         .where(eq(databaseProperties.id, propertyId))
-        .get()!;
+        .get();
+
+      if (!property) {
+        return c.json({ error: "Property not found after update" }, 500);
+      }
 
       return c.json({ property });
     }

--- a/apps/server/src/routes/pages.ts
+++ b/apps/server/src/routes/pages.ts
@@ -227,7 +227,8 @@ export const pageRoutes = new Hono<AuthEnv>()
 
     if (page.coverImage?.startsWith(`/uploads/covers/${user.id}/`)) {
       const previousPath = resolve(uploadRoot, page.coverImage.replace("/uploads/", ""));
-      if (existsSync(previousPath)) {
+      const safeBase = resolve(uploadRoot, "covers", user.id);
+      if (previousPath.startsWith(safeBase + "/") && existsSync(previousPath)) {
         unlinkSync(previousPath);
       }
     }
@@ -256,7 +257,8 @@ export const pageRoutes = new Hono<AuthEnv>()
 
     if (page.coverImage?.startsWith(`/uploads/covers/${user.id}/`)) {
       const filePath = resolve(uploadRoot, page.coverImage.replace("/uploads/", ""));
-      if (existsSync(filePath)) {
+      const safeBase = resolve(uploadRoot, "covers", user.id);
+      if (filePath.startsWith(safeBase + "/") && existsSync(filePath)) {
         unlinkSync(filePath);
       }
     }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,6 @@
     "@tanstack/react-query": "^5",
     "@tanstack/react-router": "^1",
     "emoji-mart": "^5.6.0",
-    "hono": "^4",
     "lucide-react": "^0.468",
     "react": "^19",
     "react-dom": "^19",


### PR DESCRIPTION
## Summary
- Cambia cookie di sessione `sameSite` da `"none"` a `"lax"` per ripristinare protezione CSRF
- Aggiunge header di sicurezza `X-Content-Type-Options: nosniff` e `X-Frame-Options: DENY` a tutte le risposte
- Aggiunge controllo di contenimento path per eliminazione file cover (previene path traversal)
- Sostituisce non-null assertions (`!`) con null check in databases.ts — previene crash del server
- Rimuove dipendenza `oslo` inutilizzata dal server
- Rimuove dipendenza `hono` inutilizzata dal frontend web

Closes #8

## Test plan
- [ ] Typecheck passa ✅ (verificato localmente, tutti e 3 i package)
- [ ] Verificare che login/signup funzionino con `sameSite: "lax"`
- [ ] Verificare che le risposte includano i nuovi header di sicurezza
- [ ] Testare upload e eliminazione cover image
- [ ] Verificare che creazione database e update proprietà gestiscano errori senza crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)