### PR TITLE
fix: codebase analysis findings 2026-05-09

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist/
 *.db-shm
 .env
 .env.local
+.env.*.local
+apps/server/data/

--- a/apps/server/src/db/index.ts
+++ b/apps/server/src/db/index.ts
@@ -61,7 +61,7 @@ if (tableExists("sessions")) {
   `);
 
   // Cleanup expired sessions on startup
-  sqlite.exec(`DELETE FROM sessions WHERE expires_at < ${Date.now()}`);
+  sqlite.prepare("DELETE FROM sessions WHERE expires_at < ?").run(Date.now());
 }
 
 if (tableExists("links")) {

--- a/apps/web/src/components/database/DatabaseTable.tsx
+++ b/apps/web/src/components/database/DatabaseTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { Fragment, useState, useCallback, useRef } from "react";
 import { Plus } from "lucide-react";
 import { DatabaseCell } from "./DatabaseCell";
 import { DatabaseColumnHeader } from "./DatabaseColumnHeader";
@@ -114,9 +114,8 @@ export function DatabaseTable({
 
         {/* Data rows */}
         {rows.map((row, rowIdx) => (
-          <>
+          <Fragment key={row.id}>
             <div
-              key={`n-${row.id}`}
               className="group/row flex items-center border-b border-r px-2 py-0 text-xs"
               style={{
                 borderColor: "var(--color-border)",
@@ -148,11 +147,10 @@ export function DatabaseTable({
               </div>
             ))}
             <div
-              key={`e-${row.id}`}
               className="border-b"
               style={{ borderColor: "var(--color-border)" }}
             />
-          </>
+          </Fragment>
         ))}
       </div>
 

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -4,14 +4,14 @@ export const pageFontFamilySchema = z.enum(["default", "serif", "mono"]);
 export const pageContentWidthSchema = z.enum(["normal", "wide"]);
 
 export const signupSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),
+  email: z.string().email().max(254),
+  password: z.string().min(8).max(1024),
   name: z.string().min(1).max(100),
 });
 
 export const loginSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(1),
+  email: z.string().email().max(254),
+  password: z.string().min(1).max(1024),
 });
 
 export const createPageSchema = z.object({


### PR DESCRIPTION
## Summary
- security: parametrize session-cleanup `DELETE` in `apps/server/src/db/index.ts` (AGENTS.md §10 — pattern hygiene; prior `${Date.now()}` interpolation was technically safe but a copy-paste injection trap).
- security: cap email/password length in `signupSchema`/`loginSchema` (DoS hardening — Argon2 hash cost grows with input).
- bug: replace bare React `<>` fragment in `DatabaseTable` with `<Fragment key={row.id}>` so list reconciliation tracks rows correctly.
- chore: extend `.gitignore` to cover `apps/server/data/` (untracked SQLite dir) and `.env.*.local`.

## Findings (deferred)
Not addressed in this PR — risk of scope creep, auth-area code, or needing dependency upgrades. Each becomes a follow-up issue.

- security: `POST /auth/logout` lacks `authMiddleware` → CSRF logout primitive (`apps/server/src/routes/auth.ts:100-107`). Auth-area change.
- security: file-upload MIME validation trusts client `Content-Type`; `extname(file.name)` derives extension from client. Stored-XSS vector (`apps/server/src/routes/pages.ts:213-227`). Needs `file-type` (magic-bytes) dep.
- security: `coverImage` settable via `PATCH /pages/:id` body — bypasses upload pipeline (`packages/shared/src/validators.ts:26`).
- security: missing `propertyId`/`pageId` ownership checks in `databases` reorder + cell-update routes (`apps/server/src/routes/databases.ts:317`, `:421`).
- security: `blocks.save` accepts `z.array(z.any())` with no shape/size limit (`apps/server/src/routes/blocks.ts:9`). Stored-XSS depending on renderer.
- bug: `db.transaction(() => …)` swallow path — exceptions invisible after Hono response (`pages.ts:154,293`, `databases.ts:106,354,449`).
- bug: `reorderPagesSchema` lacks ID-uniqueness `.refine`; duplicate IDs collapse sort order.
- perf: `archiveRecursive` N+1 (`pages.ts:295-309`) — needs `WITH RECURSIVE` CTE.
- perf: bulk reorder uses per-row UPDATE — switch to `CASE WHEN` (`pages.ts:154`, `databases.ts:317`).
- perf: `@emoji-mart/data` (~1MB) eagerly imported in `PageChrome.tsx` — lazy-load on dialog open.
- deps (CVEs): `drizzle-orm` <0.45.2 GHSA-gpj5-g38j-94v9 (SQLi via identifier escaping); `vite` ≤6.4.1 GHSA-p9ff-h696-f583; `hono` <4.12.18 several advisories; `postcss` <8.5.10 GHSA-qx2v-qp2m-jg93. Defer to manual review.
- infra: Dockerfile floats `oven/bun:1.3` tag, runs as root, re-installs deps in `production` stage; compose lacks healthcheck/resource limits.
- quality: form labels missing `htmlFor`/`id` (`login.tsx`, `signup.tsx`, `PageChrome.tsx` cover dialog) — a11y.
- quality: `links` table defined in schema/indexes but zero callers — dead.
- quality: `getNextSortOrder` duplicated verbatim across `pages.ts` and `databases.ts`.
- tests: zero test suite (only a port-check shell). Highest leverage: auth flow integration test.

## Sub-analyst reports

### Security
1. SQL string-interpolation pattern in startup cleanup (fixed here).
2. `/auth/logout` missing auth middleware (deferred).
3. File-upload MIME spoof + client-controlled extension → stored XSS (deferred).

### Quality
1. React fragment missing `key` in `DatabaseTable` (fixed).
2. N+1 query patterns in `pages.ts` archive/reorder (deferred — perf).
3. Duplicated `getNextSortOrder` helper (deferred).

### Bugs
1. `db.transaction` callback exceptions swallowed after response (deferred).
2. `propertyId` ownership not enforced in databases routes (deferred).
3. `reorderPagesSchema` allows duplicate IDs (deferred).

### Tests
1. No test suite at all — start with auth integration flow.
2. Cross-user isolation untested across all owned-resource routes.
3. `authMiddleware` expired-session branch never exercised.

### Deps
1. `drizzle-orm` <0.45.2 — SQL injection advisory (deferred).
2. `vite` ≤6.4.1 — dev-server file read advisory.
3. `hono` <4.12.18 — multiple advisories.

### Performance
1. Most "missing index" findings are FALSE POSITIVES — indexes are created at runtime in `apps/server/src/db/index.ts` via `CREATE INDEX IF NOT EXISTS`. Performance agent did not see them because they live outside Drizzle migrations.
2. `archiveRecursive` true N+1 (deferred).
3. Eager `@emoji-mart/data` import bloats bundle (deferred).

---
Generated automatically by Codebase Analyst — 2026-05-09