### PR TITLE
fix: codebase analysis findings 2026-05-16

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -33,7 +33,7 @@ jobs:
       COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
       IS_PR: ${{ github.event.issue.pull_request != null }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -38,7 +38,7 @@ jobs:
       EVENT_ACTION: ${{ github.event.action || 'manual' }}
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Fails the PR only on dependencies the diff introduces or bumps to a
       # vulnerable version. Reads from GitHub's Dependency graph; requires the

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ dist/
 .env.local
 .env.*.local
 apps/server/data/
+.env.*
+.DS_Store
+Thumbs.db
+mylocal.*

--- a/apps/server/src/db/index.ts
+++ b/apps/server/src/db/index.ts
@@ -46,6 +46,7 @@ if (tableExists("database_cell_values")) {
   sqlite.exec(`
     CREATE INDEX IF NOT EXISTS idx_database_cell_values_row_id ON database_cell_values(row_id);
     CREATE INDEX IF NOT EXISTS idx_database_cell_values_property_id ON database_cell_values(property_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_database_cell_values_row_property ON database_cell_values(row_id, property_id);
   `);
 }
 
@@ -71,4 +72,3 @@ if (tableExists("links")) {
   `);
 }
 export const db = drizzle(sqlite, { schema });
-export type DB = typeof db;

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -1,4 +1,5 @@
 import { sqliteTable, text, integer, real } from "drizzle-orm/sqlite-core";
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core";
 
 export const users = sqliteTable("users", {
   id: text("id").primaryKey(),
@@ -20,7 +21,7 @@ export const sessions = sqliteTable("sessions", {
 
 export const pages = sqliteTable("pages", {
   id: text("id").primaryKey(),
-  parentPageId: text("parent_page_id").references((): any => pages.id, {
+  parentPageId: text("parent_page_id").references((): AnySQLiteColumn => pages.id, {
     onDelete: "set null",
   }),
   title: text("title").notNull().default("Untitled"),

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -24,7 +24,7 @@ function createSession(c: Context, userId: string) {
   setCookie(c, "session", token, {
     httpOnly: true,
     secure: true,
-    sameSite: "lax",
+    sameSite: "strict",
     path: "/",
     maxAge: SESSION_DURATION / 1000,
   });

--- a/apps/server/src/routes/blocks.ts
+++ b/apps/server/src/routes/blocks.ts
@@ -7,7 +7,8 @@ import { eq, and } from "drizzle-orm";
 import { authMiddleware, type AuthEnv } from "../middleware/auth.js";
 
 const saveBlocksSchema = z.object({
-  content: z.array(z.any()),
+  // reason: BlockNote block shape is opaque at this boundary; cap size to prevent DoS
+  content: z.array(z.any()).max(5000),
 });
 
 export const blockRoutes = new Hono<AuthEnv>()

--- a/apps/server/src/routes/databases.ts
+++ b/apps/server/src/routes/databases.ts
@@ -8,7 +8,7 @@ import {
   databaseRows,
   databaseCellValues,
 } from "../db/schema.js";
-import { eq, and, isNull, asc } from "drizzle-orm";
+import { eq, and, isNull, desc } from "drizzle-orm";
 import {
   createDatabaseSchema,
   createPropertySchema,
@@ -34,7 +34,7 @@ function getOwnedDatabasePage(userId: string, pageId: string) {
 }
 
 function getNextSortOrder(userId: string, parentPageId: string | null) {
-  const siblings = db
+  const last = db
     .select({ sortOrder: pages.sortOrder })
     .from(pages)
     .where(
@@ -44,10 +44,11 @@ function getNextSortOrder(userId: string, parentPageId: string | null) {
         isNull(pages.archivedAt)
       )
     )
-    .orderBy(asc(pages.sortOrder), asc(pages.createdAt))
-    .all();
+    .orderBy(desc(pages.sortOrder))
+    .limit(1)
+    .get();
 
-  return siblings.length === 0 ? 0 : siblings[siblings.length - 1].sortOrder + 1;
+  return last ? last.sortOrder + 1 : 0;
 }
 
 function getLockedError(page: { isLocked: boolean }) {
@@ -314,6 +315,21 @@ export const databaseRoutes = new Hono<AuthEnv>()
       const lockError = getLockedError(page);
       if (lockError) return c.json(lockError, 423);
 
+      const existingProperties = db
+        .select({ id: databaseProperties.id })
+        .from(databaseProperties)
+        .where(eq(databaseProperties.pageId, pageId))
+        .all();
+
+      const existingIds = new Set(existingProperties.map((p) => p.id));
+      if (
+        propertyIds.length !== existingIds.size ||
+        new Set(propertyIds).size !== propertyIds.length ||
+        propertyIds.some((id) => !existingIds.has(id))
+      ) {
+        return c.json({ error: "Property IDs must be a permutation of the existing properties" }, 400);
+      }
+
       db.transaction(() => {
         for (let i = 0; i < propertyIds.length; i++) {
           db.update(databaseProperties)
@@ -350,6 +366,20 @@ export const databaseRoutes = new Hono<AuthEnv>()
 
       const now = Date.now();
       const rowId = nanoid();
+
+      if (input.cells && Object.keys(input.cells).length > 0) {
+        const validProperties = db
+          .select({ id: databaseProperties.id })
+          .from(databaseProperties)
+          .where(eq(databaseProperties.pageId, pageId))
+          .all();
+        const validPropertyIds = new Set(validProperties.map((p) => p.id));
+        for (const propertyId of Object.keys(input.cells)) {
+          if (!validPropertyIds.has(propertyId)) {
+            return c.json({ error: "Invalid property ID" }, 400);
+          }
+        }
+      }
 
       db.transaction(() => {
         db.insert(databaseRows)
@@ -444,6 +474,21 @@ export const databaseRoutes = new Hono<AuthEnv>()
 
       if (!row) {
         return c.json({ error: "Row not found" }, 404);
+      }
+
+      const property = db
+        .select({ id: databaseProperties.id })
+        .from(databaseProperties)
+        .where(
+          and(
+            eq(databaseProperties.id, propertyId),
+            eq(databaseProperties.pageId, pageId)
+          )
+        )
+        .get();
+
+      if (!property) {
+        return c.json({ error: "Property not found" }, 404);
       }
 
       db.transaction(() => {

--- a/apps/server/src/routes/pages.ts
+++ b/apps/server/src/routes/pages.ts
@@ -3,7 +3,7 @@ import { zValidator } from "@hono/zod-validator";
 import { nanoid } from "nanoid";
 import { db } from "../db/index.js";
 import { pages } from "../db/schema.js";
-import { eq, isNull, and, asc } from "drizzle-orm";
+import { eq, isNull, and, desc } from "drizzle-orm";
 import {
   createPageSchema,
   updatePageSchema,
@@ -14,6 +14,8 @@ import { mkdirSync, existsSync, unlinkSync } from "fs";
 import { resolve, extname } from "path";
 
 const uploadRoot = resolve(import.meta.dir, "../../data/uploads");
+const MAX_UPLOAD_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_COVER_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".gif", ".webp", ".avif"]);
 
 function getOwnedPage(userId: string, pageId: string) {
   return db
@@ -24,7 +26,7 @@ function getOwnedPage(userId: string, pageId: string) {
 }
 
 function getNextSortOrder(userId: string, parentPageId: string | null) {
-  const siblings = db
+  const last = db
     .select({ sortOrder: pages.sortOrder })
     .from(pages)
     .where(
@@ -34,10 +36,11 @@ function getNextSortOrder(userId: string, parentPageId: string | null) {
         isNull(pages.archivedAt)
       )
     )
-    .orderBy(asc(pages.sortOrder), asc(pages.createdAt))
-    .all();
+    .orderBy(desc(pages.sortOrder))
+    .limit(1)
+    .get();
 
-  return siblings.length === 0 ? 0 : siblings[siblings.length - 1].sortOrder + 1;
+  return last ? last.sortOrder + 1 : 0;
 }
 
 function isUnlockOnlyUpdate(input: Record<string, unknown>) {
@@ -141,6 +144,10 @@ export const pageRoutes = new Hono<AuthEnv>()
       return c.json({ error: "Ordered pages must match the sibling set" }, 400);
     }
 
+    if (new Set(orderedPageIds).size !== orderedPageIds.length) {
+      return c.json({ error: "Ordered pages must not contain duplicates" }, 400);
+    }
+
     const siblingIds = new Set(siblingPages.map((page) => page.id));
     if (orderedPageIds.some((id) => !siblingIds.has(id))) {
       return c.json({ error: "Ordered pages must all belong to the same sibling set" }, 400);
@@ -216,7 +223,6 @@ export const pageRoutes = new Hono<AuthEnv>()
     if (!file.type.startsWith("image/")) {
       return c.json({ error: "Only image uploads are supported" }, 400);
     }
-    const MAX_UPLOAD_SIZE = 5 * 1024 * 1024; // 5MB
     if (file.size > MAX_UPLOAD_SIZE) {
       return c.json({ error: "File too large (max 5MB)" }, 413);
     }
@@ -224,8 +230,11 @@ export const pageRoutes = new Hono<AuthEnv>()
     const userDir = resolve(uploadRoot, "covers", user.id);
     mkdirSync(userDir, { recursive: true });
 
-    const suffix = extname(file.name || "").replace(/[^a-zA-Z0-9.]/g, "") || ".bin";
-    const filename = `${Date.now()}-${nanoid()}${suffix}`;
+    const rawExt = extname(file.name || "").toLowerCase().replace(/[^a-z0-9.]/g, "");
+    if (!ALLOWED_COVER_EXTENSIONS.has(rawExt)) {
+      return c.json({ error: "Unsupported image format" }, 400);
+    }
+    const filename = `${Date.now()}-${nanoid()}${rawExt}`;
     const filePath = resolve(userDir, filename);
     await Bun.write(filePath, file);
 

--- a/apps/web/src/components/database/DatabaseCell.tsx
+++ b/apps/web/src/components/database/DatabaseCell.tsx
@@ -221,7 +221,7 @@ const SELECT_COLORS = [
   "bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200",
 ];
 
-function getColorForOption(option: string, index: number) {
+function getColorForOption(_option: string, index: number) {
   return SELECT_COLORS[index % SELECT_COLORS.length];
 }
 
@@ -346,7 +346,7 @@ function MultiSelectCell({
         className={`flex h-full w-full flex-wrap items-center gap-1 px-2 py-1 ${disabled ? "" : "cursor-pointer"}`}
         onClick={() => !disabled && setOpen(!open)}
       >
-        {selected.map((s, i) => (
+        {selected.map((s) => (
           <span
             key={s}
             className={`inline-block rounded-sm px-1.5 py-0.5 text-xs font-medium ${getColorForOption(s, options.indexOf(s))}`}

--- a/apps/web/src/components/page/PageChrome.tsx
+++ b/apps/web/src/components/page/PageChrome.tsx
@@ -122,7 +122,7 @@ export function PageChrome({
           }}
         >
           {page.coverImage ? (
-            <img src={page.coverImage} alt="" className="h-full w-full object-cover" />
+            <img src={page.coverImage} alt="" loading="lazy" className="h-full w-full object-cover" />
           ) : (
             <Dialog.Trigger asChild disabled={page.isLocked}>
               <button
@@ -178,11 +178,14 @@ export function PageChrome({
 
             <div className="space-y-4">
               <div className="space-y-2">
-                <label className="text-sm font-medium" style={{ color: "var(--color-text)" }}>
+                <label htmlFor="cover-url" className="text-sm font-medium" style={{ color: "var(--color-text)" }}>
                   Image URL
                 </label>
                 <input
+                  id="cover-url"
+                  name="coverUrl"
                   type="url"
+                  autoComplete="off"
                   value={coverUrl}
                   onChange={(event) => setCoverUrl(event.target.value)}
                   placeholder="https://example.com/cover.jpg"
@@ -202,10 +205,12 @@ export function PageChrome({
               </div>
 
               <div className="space-y-2">
-                <label className="text-sm font-medium" style={{ color: "var(--color-text)" }}>
+                <label htmlFor="cover-file" className="text-sm font-medium" style={{ color: "var(--color-text)" }}>
                   Upload image
                 </label>
                 <input
+                  id="cover-file"
+                  name="coverFile"
                   type="file"
                   accept="image/*"
                   disabled={page.isLocked || coverBusy}

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -52,12 +52,15 @@ function LoginPage() {
           )}
 
           <div>
-            <label className="block text-sm font-medium mb-1"
+            <label htmlFor="login-email" className="block text-sm font-medium mb-1"
               style={{ color: "var(--color-text-secondary)" }}>
               Email
             </label>
             <input
+              id="login-email"
+              name="email"
               type="email"
+              autoComplete="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
@@ -71,12 +74,15 @@ function LoginPage() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium mb-1"
+            <label htmlFor="login-password" className="block text-sm font-medium mb-1"
               style={{ color: "var(--color-text-secondary)" }}>
               Password
             </label>
             <input
+              id="login-password"
+              name="password"
               type="password"
+              autoComplete="current-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -53,12 +53,15 @@ function SignupPage() {
           )}
 
           <div>
-            <label className="block text-sm font-medium mb-1"
+            <label htmlFor="signup-name" className="block text-sm font-medium mb-1"
               style={{ color: "var(--color-text-secondary)" }}>
               Name
             </label>
             <input
+              id="signup-name"
+              name="name"
               type="text"
+              autoComplete="name"
               value={name}
               onChange={(e) => setName(e.target.value)}
               required
@@ -72,12 +75,15 @@ function SignupPage() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium mb-1"
+            <label htmlFor="signup-email" className="block text-sm font-medium mb-1"
               style={{ color: "var(--color-text-secondary)" }}>
               Email
             </label>
             <input
+              id="signup-email"
+              name="email"
               type="email"
+              autoComplete="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
@@ -91,12 +97,15 @@ function SignupPage() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium mb-1"
+            <label htmlFor="signup-password" className="block text-sm font-medium mb-1"
               style={{ color: "var(--color-text-secondary)" }}>
               Password
             </label>
             <input
+              id="signup-password"
+              name="password"
               type="password"
+              autoComplete="new-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -6,13 +6,6 @@ export interface User {
   createdAt: number;
 }
 
-export interface Session {
-  id: string;
-  userId: string;
-  token: string;
-  expiresAt: number;
-}
-
 export interface Page {
   id: string;
   parentPageId: string | null;
@@ -68,15 +61,6 @@ export interface DatabaseCellValue {
 
 export interface DatabaseRowWithCells extends DatabaseRow {
   cells: Record<string, unknown>;
-}
-
-export interface Link {
-  id: string;
-  sourcePageId: string;
-  sourceBlockId: string | null;
-  targetPageId: string;
-  type: "mention" | "link" | "relation";
-  createdAt: number;
 }
 
 export interface PageTreeItem {

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -23,7 +23,7 @@ export const createPageSchema = z.object({
 export const updatePageSchema = z.object({
   title: z.string().optional(),
   icon: z.string().nullable().optional(),
-  coverImage: z.string().nullable().optional(),
+  coverImage: z.string().url().max(2048).regex(/^https:\/\//i, "Cover must be an https:// URL").nullable().optional(),
   parentPageId: z.string().nullable().optional(),
   fontFamily: pageFontFamilySchema.optional(),
   contentWidth: pageContentWidthSchema.optional(),


### PR DESCRIPTION
## Summary

- **Security**: session cookie `sameSite` lax → strict
- **Security**: database routes now validate `propertyId` belongs to the target `pageId` before writing cells (broken object-level authorization fix)
- **Security**: `reorderProperties` validates the payload is a full permutation of existing properties (no silent omissions or cross-database rewrites)
- **Security**: cover upload enforces an extension allowlist (`jpg/jpeg/png/gif/webp/avif`); previously a client could upload `.html`/`.svg` files
- **Security**: `coverImage` in `updatePageSchema` restricted to `https://` URLs ≤ 2048 chars
- **Security**: block `content` array capped at 5000 elements (DoS protection)
- **Security/CI**: SHA-pin `actions/checkout@v4` → commit SHA in all 3 workflow files
- **Bug**: `PUT /pages/reorder` now rejects duplicate IDs before the membership check (corruption vector)
- **Performance**: `getNextSortOrder` uses `DESC LIMIT 1` instead of loading all siblings
- **Performance**: composite UNIQUE index added on `database_cell_values(row_id, property_id)`
- **Quality**: `references((): any)` → `references((): AnySQLiteColumn)` in schema
- **Quality**: dead exports removed (`Session`, `Link`, `DB`)
- **Quality/a11y**: `htmlFor`/`id`/`name`/`autocomplete` added to all form inputs in login, signup, PageChrome cover dialog
- **Quality**: cover image gets `loading="lazy"`; unused function params/vars cleaned up
- **Infra**: `.gitignore` gains `.env.*`, `.DS_Store`, `Thumbs.db`, `mylocal.*`

## Findings (deferred)

- **Deps**: `drizzle-orm@0.39.3` (SQL injection CVE GHSA-gpj5-g38j-94v9), `hono@4.12.8` (10 advisories), `vite@6.4.1` (arbitrary file read), `postcss` (XSS) — all require `bun update` + manual regression test
- **Dockerfile**: no non-root `USER bun`; no `healthcheck:` block
- **Performance**: `archiveRecursive` is recursive JS (stack overflow risk on deep trees) — needs refactor to iterative BFS
- **Performance**: heavy static `import data from "@emoji-mart/data"` (~1MB) should be a dynamic import inside dialog open
- **Tests**: zero application tests exist — highest-risk gap, warrants a dedicated test sprint
- **Security (medium)**: `POST /databases` reads page after transaction (outside transaction scope)

## Sub-analyst reports

- **Security**: top findings — broken IDOR on cell writes (shipped fix), upload MIME bypass (shipped fix), unbounded block payload (shipped fix)
- **Quality**: top findings — missing a11y labels (shipped), dead exports (shipped), duplicate `getNextSortOrder` (deferred: refactor scope)
- **Bugs**: top findings — reorder accepts duplicate IDs (shipped), reorderProperties accepts non-permutations (shipped), file extension bypass (shipped)
- **Tests**: zero tests exist — deferred (warrants own PR/sprint)
- **Deps**: drizzle-orm SQL injection CVE, hono 10 advisories, vite arbitrary file read — all deferred (require upgrade + testing)
- **Performance**: missing composite index (shipped), N+1 archive recursive (deferred), emoji ~1MB static import (deferred)

---
Generated automatically by Codebase Analyst — 2026-05-16