### PR TITLE
fix: codebase analysis findings 2026-05-19

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -2,6 +2,8 @@ name: Auto-assign issues
 on:
   issues:
     types: [opened]
+permissions:
+  contents: read
 jobs:
   assign:
     runs-on: ubuntu-latest

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -55,7 +55,6 @@ if (existsSync(staticDir)) {
     "/*",
     serveStatic({
       root: staticDir,
-      rewriteRequestPath: (path) => path,
     })
   );
   // SPA fallback: serve index.html for non-API, non-file routes

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -10,9 +10,10 @@ import { signupSchema, loginSchema } from "@notes/shared";
 import { authMiddleware } from "../middleware/auth.js";
 
 const SESSION_DURATION = 30 * 24 * 60 * 60 * 1000; // 30 days
+const SESSION_TOKEN_LENGTH = 32;
 
 function createSession(c: Context, userId: string) {
-  const token = nanoid(32);
+  const token = nanoid(SESSION_TOKEN_LENGTH);
   db.insert(sessions)
     .values({
       id: nanoid(),

--- a/apps/server/src/routes/databases.ts
+++ b/apps/server/src/routes/databases.ts
@@ -8,7 +8,7 @@ import {
   databaseRows,
   databaseCellValues,
 } from "../db/schema.js";
-import { eq, and, isNull, asc } from "drizzle-orm";
+import { eq, and, isNull, asc, max } from "drizzle-orm";
 import {
   createDatabaseSchema,
   createPropertySchema,
@@ -34,8 +34,8 @@ function getOwnedDatabasePage(userId: string, pageId: string) {
 }
 
 function getNextSortOrder(userId: string, parentPageId: string | null) {
-  const siblings = db
-    .select({ sortOrder: pages.sortOrder })
+  const result = db
+    .select({ maxOrder: max(pages.sortOrder) })
     .from(pages)
     .where(
       and(
@@ -44,10 +44,8 @@ function getNextSortOrder(userId: string, parentPageId: string | null) {
         isNull(pages.archivedAt)
       )
     )
-    .orderBy(asc(pages.sortOrder), asc(pages.createdAt))
-    .all();
-
-  return siblings.length === 0 ? 0 : siblings[siblings.length - 1].sortOrder + 1;
+    .get();
+  return result?.maxOrder == null ? 0 : result.maxOrder + 1;
 }
 
 function getLockedError(page: { isLocked: boolean }) {
@@ -379,6 +377,19 @@ export const databaseRoutes = new Hono<AuthEnv>()
 
       const now = Date.now();
       const rowId = nanoid();
+
+      if (input.cells && Object.keys(input.cells).length > 0) {
+        const validProperties = db
+          .select({ id: databaseProperties.id })
+          .from(databaseProperties)
+          .where(eq(databaseProperties.pageId, pageId))
+          .all();
+        const validPropertyIds = new Set(validProperties.map((p) => p.id));
+        const invalidId = Object.keys(input.cells).find((pid) => !validPropertyIds.has(pid));
+        if (invalidId) {
+          return c.json({ error: "Invalid property ID in cells" }, 400);
+        }
+      }
 
       db.transaction(() => {
         db.insert(databaseRows)

--- a/apps/server/src/routes/pages.ts
+++ b/apps/server/src/routes/pages.ts
@@ -3,14 +3,14 @@ import { zValidator } from "@hono/zod-validator";
 import { nanoid } from "nanoid";
 import { db } from "../db/index.js";
 import { pages } from "../db/schema.js";
-import { eq, isNull, and, asc } from "drizzle-orm";
+import { eq, isNull, and, asc, max } from "drizzle-orm";
 import {
   createPageSchema,
   updatePageSchema,
   reorderPagesSchema,
 } from "@notes/shared";
 import { authMiddleware, type AuthEnv } from "../middleware/auth.js";
-import { mkdirSync, existsSync, unlinkSync } from "fs";
+import { mkdirSync, unlinkSync } from "fs";
 import { resolve, extname } from "path";
 
 const uploadRoot = resolve(import.meta.dir, "../../data/uploads");
@@ -34,8 +34,8 @@ function getOwnedPage(userId: string, pageId: string) {
 }
 
 function getNextSortOrder(userId: string, parentPageId: string | null) {
-  const siblings = db
-    .select({ sortOrder: pages.sortOrder })
+  const result = db
+    .select({ maxOrder: max(pages.sortOrder) })
     .from(pages)
     .where(
       and(
@@ -44,10 +44,8 @@ function getNextSortOrder(userId: string, parentPageId: string | null) {
         isNull(pages.archivedAt)
       )
     )
-    .orderBy(asc(pages.sortOrder), asc(pages.createdAt))
-    .all();
-
-  return siblings.length === 0 ? 0 : siblings[siblings.length - 1].sortOrder + 1;
+    .get();
+  return result?.maxOrder == null ? 0 : result.maxOrder + 1;
 }
 
 function isUnlockOnlyUpdate(input: Record<string, unknown>) {
@@ -198,6 +196,15 @@ export const pageRoutes = new Hono<AuthEnv>()
       input.parentPageId !== undefined &&
       input.parentPageId !== existing.parentPageId
     ) {
+      if (input.parentPageId === id) {
+        return c.json({ error: "A page cannot be its own parent" }, 400);
+      }
+      if (input.parentPageId !== null) {
+        const targetParent = getOwnedPage(user.id, input.parentPageId);
+        if (!targetParent) {
+          return c.json({ error: "Parent page not found" }, 404);
+        }
+      }
       updates.sortOrder = getNextSortOrder(user.id, input.parentPageId ?? null);
     }
 
@@ -232,7 +239,7 @@ export const pageRoutes = new Hono<AuthEnv>()
       return c.json({ error: "Only image uploads are supported" }, 400);
     }
     if (file.size > MAX_UPLOAD_SIZE) {
-      return c.json({ error: "File too large (max 5MB)" }, 413);
+      return c.json({ error: `File too large (max ${MAX_UPLOAD_SIZE / (1024 * 1024)}MB)` }, 413);
     }
     const suffix = extname(file.name || "").toLowerCase();
     if (!ALLOWED_COVER_EXTENSIONS.has(suffix)) {
@@ -252,8 +259,12 @@ export const pageRoutes = new Hono<AuthEnv>()
     if (page.coverImage?.startsWith(`/uploads/covers/${user.id}/`)) {
       const previousPath = resolve(uploadRoot, page.coverImage.replace("/uploads/", ""));
       const safeBase = resolve(uploadRoot, "covers", user.id);
-      if (previousPath.startsWith(safeBase + "/") && existsSync(previousPath)) {
-        unlinkSync(previousPath);
+      if (previousPath.startsWith(safeBase + "/")) {
+        try {
+          unlinkSync(previousPath);
+        } catch (e: unknown) {
+          if ((e as { code?: string }).code !== "ENOENT") throw e;
+        }
       }
     }
 
@@ -282,8 +293,12 @@ export const pageRoutes = new Hono<AuthEnv>()
     if (page.coverImage?.startsWith(`/uploads/covers/${user.id}/`)) {
       const filePath = resolve(uploadRoot, page.coverImage.replace("/uploads/", ""));
       const safeBase = resolve(uploadRoot, "covers", user.id);
-      if (filePath.startsWith(safeBase + "/") && existsSync(filePath)) {
-        unlinkSync(filePath);
+      if (filePath.startsWith(safeBase + "/")) {
+        try {
+          unlinkSync(filePath);
+        } catch (e: unknown) {
+          if ((e as { code?: string }).code !== "ENOENT") throw e;
+        }
       }
     }
 

--- a/packages/shared/src/validators.ts
+++ b/packages/shared/src/validators.ts
@@ -25,10 +25,11 @@ const coverImageSchema = z
   .max(2048)
   .refine(
     (value) =>
-      value.startsWith("https://") || value.startsWith("/uploads/"),
+      value.startsWith("https://") ||
+      /^\/uploads\/covers\/[\w-]+\/[\w-]+\.[a-z]+$/.test(value),
     {
       message:
-        "coverImage must be an https:// URL or an internal /uploads/ path",
+        "coverImage must be an https:// URL or a valid internal /uploads/covers/ path",
     }
   );
 
@@ -75,7 +76,7 @@ export const updatePropertySchema = z.object({
 });
 
 export const reorderPropertiesSchema = z.object({
-  propertyIds: z.array(z.string()),
+  propertyIds: z.array(z.string()).min(1),
 });
 
 export const createRowSchema = z.object({


### PR DESCRIPTION
## Summary

- **[SECURITY]** `validators.ts`: `coverImage` path traversal fix — strict regex rejects `/../../../etc/passwd`-style values
- **[SECURITY/BUG]** `pages.ts`: `PATCH /:id` now validates `parentPageId` ownership — prevents reparenting pages to another user's tree (IDOR)
- **[SECURITY/BUG]** `databases.ts`: `createRow` validates all `propertyId` keys in `cells` against the owning database before inserting
- **[BUG]** `pages.ts`: TOCTOU race on cover-image deletion fixed — `existsSync + unlinkSync` replaced with `try { unlinkSync } catch ENOENT`
- **[BUG]** `pages.ts`: reject `parentPageId === id` (page cannot be its own parent)
- **[PERF]** `pages.ts` + `databases.ts`: `getNextSortOrder` now uses `SELECT MAX(sort_order)` instead of fetching all sibling rows
- **[QUALITY]** `validators.ts`: `reorderPropertiesSchema.propertyIds` now has `.min(1)` guard
- **[QUALITY]** `auth.ts`: `nanoid(32)` → named constant `SESSION_TOKEN_LENGTH`
- **[QUALITY]** `pages.ts`: upload error message derived from `MAX_UPLOAD_SIZE` constant
- **[QUALITY]** `index.ts`: remove no-op `rewriteRequestPath: (path) => path`
- **[CI]** `auto-assign.yml`: add top-level `permissions: contents: read`

## Findings (deferred — higher risk or requires manual review)

- **[DEP]** Bump `hono` ≥4.12.18 (multiple CVEs: cache leak, cookie spoofing, middleware bypass) — defer to Dependabot
- **[DEP]** Bump `vite` ≥6.4.2 (GHSA-p9ff-h696-f583: dev server file read) — defer to Dependabot
- **[DEP]** Bump `postcss` ≥8.5.10 (GHSA-qx2v-qp2m-jg93: XSS in CSS stringify) — defer to Dependabot
- **[SECURITY]** No magic-bytes validation for file uploads — needs `file-type` npm package evaluation
- **[SECURITY]** `/uploads/*` served without authentication — design decision needed
- **[SECURITY]** No rate limiting on `/api/auth/login` — needs rate-limit middleware
- **[SECURITY]** No `Content-Security-Policy` header — needs CSP tuning
- **[QUALITY]** Dead `links` table schema + indexes (zero routes reference it) — needs product decision
- **[PERF]** Unconditional `import data from "@emoji-mart/data"` (~1MB JSON) — lazy-load behind dynamic import
- **[PERF]** Recursive `archiveRecursive` → unbounded N+1; replace with recursive CTE
- **[CI]** Pin `pozil/auto-assign-issue@v2` to commit SHA — needs SHA lookup

## Sub-analyst reports

- **Security**: MIME bypass via client Content-Type (HIGH); unauthenticated /uploads/* (HIGH); coverImage path traversal (MEDIUM); no rate limiting on auth (MEDIUM)
- **Quality**: `any` types without reason comments in blocks/api/editor (HIGH); `getNextSortOrder` duplicated (HIGH); unawaited async in editor cleanup (HIGH)
- **Bugs**: parentPageId auth bypass (CRITICAL); TOCTOU on cover delete (CRITICAL); createRow propertyId bypass (CRITICAL); recursive archive unbounded depth (HIGH)
- **Tests**: POST /cover-upload MIME cross-check uncovered; DELETE /cover zero tests; parentPageId=self not tested; api client methods (update/reorder/delete) untested
- **Deps**: vite ≤6.4.1 (2× High CVE); hono <4.12.18 (5× Medium CVE); postcss <8.5.10 (Medium CVE); esbuild ≤0.24.2 (Medium, dev only)
- **Performance**: N+1 in page/property reorder loops; getNextSortOrder fetch-all; missing composite PK on database_cell_values; 1MB emoji dataset loaded unconditionally

---
Generated automatically by Codebase Analyst — 2026-05-19