### PR TITLE
ci: harden dependabot workflows + switch CodeQL to advanced setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         language: [javascript-typescript, actions]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # No paths-ignore: every PR must post the status so branch protection
+    # required checks ("Analyze (javascript-typescript)") never stay
+    # stuck in "Expected — Waiting for status to be reported".
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, actions]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,10 +33,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0
+      - uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
-      - uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0
+      - uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,10 +31,12 @@ jobs:
         language: [javascript-typescript, actions]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: github/codeql-action/init@v3
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0
         with:
           category: "/language:${{ matrix.language }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,7 @@ before any of the rules below.
   shell injection.
 - Do not skip CI hooks (`--no-verify`, `[skip ci]`, `[ci skip]`)
   without an explicit reason in the PR description.
-- Every new test added must run in a CI job, and every new CI job that gates correctness must be added to `main`'s required status checks in the same PR 
+- Every new test added must run in a CI job, and every new CI job that gates correctness must be added to `main`'s required status checks in the same PR.
 
 ## 15. Accessibility (frontend)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,7 @@ before any of the rules below.
   shell injection.
 - Do not skip CI hooks (`--no-verify`, `[skip ci]`, `[ci skip]`)
   without an explicit reason in the PR description.
+- Every new test added must run in a CI job, and every new CI job that gates correctness must be added to `main`'s required status checks in the same PR 
 
 ## 15. Accessibility (frontend)
 


### PR DESCRIPTION
## Summary

- Hardens dependabot review workflows (`claude-pr-review-dependabot.yml`, `dependabot-auto-merge.yml`) per prior CodeRabbit pass.
- Replaces CodeQL **Default Setup** with an advanced workflow (`.github/workflows/codeql.yml`) so the required check `Analyze (javascript-typescript)` is always posted on every PR — not skipped when a PR touches only YAML/MD (this was the root cause of #48 staying in "Expected — Waiting for status to be reported" forever).
- Adds AGENTS.md §14 rule: every new test must run in CI, every new correctness-gating job must be added to `main`'s required status checks in the same PR.

## Why CodeQL change matters

GitHub's CodeQL Default Setup auto-skips analysis on PRs that touch only workflow YAML or markdown. Branch protection on `main` requires `Analyze (javascript-typescript)` → check stays pending → PR unmergeable. Advanced workflow runs unconditionally, status always posted.

Matrix `[javascript-typescript, actions]` covers the same surface as prior Default Setup (`actions, javascript, javascript-typescript, typescript`); `javascript` and `typescript` are deprecated aliases that resolve to `javascript-typescript`.

## Operational prerequisite

Default Setup has already been disabled via API (`PATCH /repos/.../code-scanning/default-setup state=not-configured`) before merging, to prevent both setups racing on the same category.

## Test plan

- [ ] CI green on this PR (advanced CodeQL workflow runs and posts `Analyze (javascript-typescript)` + `Analyze (actions)`)
- [ ] After merge, verify a follow-up PR that touches only YAML still receives a posted CodeQL status (regression check for the original #48 issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)