### PR TITLE
chore(agents-md): require SHA-pin for third-party GitHub Actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,10 +198,13 @@ before any of the rules below.
 
 - Every workflow has a top-level `permissions:` block. Default to
   `contents: read`. Widen per-job only when needed.
-- Track third-party actions at their latest stable tag (`@v4`).
-  Dependabot bumps the tag when a new major lands; review the
-  changelog and merge. Pin to SHA only when an action's repo has had
-  a tag-moving incident.
+- All third-party GitHub Actions (anything not under `actions/*` or
+  `github/*`) must be pinned to a full commit SHA with a `# vX.Y.Z`
+  comment. The comment lets Dependabot keep bumping the SHA. SHA
+  pinning prevents a tag from being silently rewritten to a
+  malicious commit by a compromised maintainer account.
+- GitHub-owned actions (`actions/*`, `github/*`): tag (`@v4`) is
+  acceptable; SHA pin preferred for defense-in-depth.
 - Never interpolate user-controlled input directly into `run:`
   blocks. Pipe through `env:`:
 


### PR DESCRIPTION
## Summary

- Updates AGENTS.md §14: third-party GitHub Actions must be pinned to a full commit SHA with `# vX.Y.Z` comment (Dependabot still bumps SHA+comment together).
- GitHub-owned actions (\`actions/*\`, \`github/*\`) may keep tags; SHA preferred for defense-in-depth.

## Why

Tag references can be silently rewritten by a compromised maintainer account. SHA pins are immutable. Dependabot supports SHA bumps when a \`# vX.Y.Z\` comment is present, so maintenance cost stays low.

This change also corrects a self-inflicted bug surfaced in #59: I'd interpreted §14 as forbidding SHA pins on github-owned actions, which led to a tag-revert commit. The new wording removes that ambiguity.

## Follow-up (not in this PR)

- Audit existing workflows and convert third-party tags to SHA pins.
- Verify \`.github/dependabot.yml\` includes the \`github-actions\` ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)